### PR TITLE
lua: added support for Lua 5.2 up

### DIFF
--- a/src/addon.c
+++ b/src/addon.c
@@ -225,21 +225,26 @@ void addon_lua_register(lua_State *L) {
 
 	// Register the POMLOG_* variables
 	lua_pushinteger(L, 1);
-	lua_setfield(L, LUA_GLOBALSINDEX, "POMLOG_ERR");
+	lua_setglobal(L, "POMLOG_ERR");
+	//lua_setfield(L, LUA_GLOBALSINDEX, "POMLOG_ERR");
 
 	lua_pushinteger(L, 2);
-	lua_setfield(L, LUA_GLOBALSINDEX, "POMLOG_WARN");
+	lua_setglobal(L, "POMLOG_WARN");
+	//lua_setfield(L, LUA_GLOBALSINDEX, "POMLOG_WARN");
 
 	lua_pushinteger(L, 3);
-	lua_setfield(L, LUA_GLOBALSINDEX, "POMLOG_INFO");
+	lua_setglobal(L, "POMLOG_INFO");
+	//lua_setfield(L, LUA_GLOBALSINDEX, "POMLOG_INFO");
 
 	lua_pushinteger(L, 4);
-	lua_setfield(L, LUA_GLOBALSINDEX, "POMLOG_DEBUG");
+	lua_setglobal(L, "POMLOG_DEBUG");
+	//lua_setfield(L, LUA_GLOBALSINDEX, "POMLOG_DEBUG");
 
 	// Replace print() by our logging function
 	
 	lua_pushcfunction(L, addon_log);
-	lua_setfield(L, LUA_GLOBALSINDEX, "print");
+	lua_setglobal(L, "print");
+	//lua_setfield(L, LUA_GLOBALSINDEX, "print");
 
 	struct luaL_Reg dns_l[] = {
 		{ "forward_lookup", addon_dns_forward_lookup },


### PR DESCRIPTION
Newer version of Lua (i.e. 5.2 upwards, for reference see for example : http://lua-users.org/wiki/LuaFiveTwo)
removed the pseudo index LUA_GLOBALSINDEX, that was already in deprecated state in Lua 5.1 .
The LUA_GLOBALSINDEX call have been substituted with the lua_setglobal call, that is compatible with 5.1 too.
